### PR TITLE
minor change to curl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ***I dont think this will work until the repo is public***
 
 ```bash
-$ bash -e "$(curl -fsSL https://raw.githubusercontent.com/parkerduckworth/halyard/master/install)"
+$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/parkerduckworth/halyard/master/install)"
 ```
 
 ## Usage


### PR DESCRIPTION
I temporarily made a repo called 'halyard' and tested out the install command from the README. I made a minor tweak to the command, and the install script now works as expected:

1. clone the repo to the users home directory
2. copies the main script to /usr/local/bin and gives it executable permission
3. Locks the Dockerfile and builds the docker image in the "container" directory

Everything works well once the install is complete.

Noted, this will only work if the projects is located at github.com/parkerduckworth/halyard , rather than halyard-dev

Also, rather than continuing to commit to master like a heathen, I will from now on push changes through new branches.

Setting up CI wouldn't be a bad idea either, once all the code has been cleaned to meet the Google Shell style guide (BTW, I didn't decide to conform to this until after the code was written, and it was an arbitrary choice. If you have a better idea, let me know)