### PR TITLE
indents should be two spaces with no tabs

### DIFF
--- a/halyard
+++ b/halyard
@@ -8,95 +8,95 @@ HALYARD_PATH="$HOME/halyard"
 CONTAINER_PATH="$HALYARD_PATH/container"
 
 copy_files() {
-    # Optional flag
-    OPT=$1
-    FILES="${@:2}"
+  # Optional flag
+  OPT=$1
+  FILES="${@:2}"
 
-    for FILE in $FILES ; do
-        echo "Loading ${FILE##*/}"
-        cp $OPT $FILE $CONTAINER_PATH
-    done
+  for FILE in $FILES; do
+    echo "Loading ${FILE##*/}"
+    cp $OPT $FILE $CONTAINER_PATH
+  done
 }
 
 load() {
-    cat $HALYARD_PATH/images/logo
+  cat $HALYARD_PATH/images/logo
 
-    # Initially we are looking at all args
-    TARGET="$@"
+  # Initially we are looking at all args
+  TARGET="$@"
 
-    if [ $1 = "-y" ] ; then
-        ARG=$2
-        # If --yes option is provided, target begins at 2nd arg
-        TARGET="${@:2}"
-    else
-        ARG=$1
-        OPT=-i
-    fi
+  if [ $1 = "-y" ]; then
+    ARG=$2
+    # If --yes option is provided, target begins at 2nd arg
+    TARGET="${@:2}"
+  else
+    ARG=$1
+    OPT=-i
+  fi
 
-    if [ -d $ARG ] ; then
-        echo "Preparing contents of ${PWD##*/}..."
-        # Since provided target is a dir, switch target to its contents
-        TARGET=$ARG/*
-    fi
+  if [ -d $ARG ]; then
+    echo "Preparing contents of ${PWD##*/}..."
+    # Since provided target is a dir, switch target to its contents
+    TARGET=$ARG/*
+  fi
 
-    copy_files "${OPT}" "${TARGET}"
+  copy_files "${OPT}" "${TARGET}"
 }
 
 run() {
-    # Ensure Docker Desktop is up
-    open --background -a Docker && 
-        if ! docker system info > /dev/null 2>&1 ; then
-            echo "Staring Docker..." &&
-            while ! docker system info > /dev/null 2>&1 ; do 
-                sleep 1; 
-            done
-        fi
+  # Ensure Docker Desktop is up
+  open --background -a Docker &&
+    if ! docker system info >/dev/null 2>&1; then
+      echo "Staring Docker..." &&
+        while ! docker system info >/dev/null 2>&1; do
+          sleep 1
+        done
+    fi
 
-    TARGET=() # Container for source files
+  TARGET=() # Container for source files
 
-    for FILE in $CONTAINER_PATH/* ; do
-        EXTENSION="${FILE##*.}"
-        # Set compiler based on source extension
-        if [ $EXTENSION = "c" ] || [ $EXTENSION = "cpp" ] || [ $EXTENSION = "cc" ]; then
-            case $EXTENSION in
-                "c")        COMPILER="gcc" ;;
-                "cpp"|"cc") COMPILER="g++" ;;
-            esac
-            TARGET+=("${FILE##*/}")
-        fi
-    done
+  for FILE in $CONTAINER_PATH/*; do
+    EXTENSION="${FILE##*.}"
+    # Set compiler based on source extension
+    if [ $EXTENSION = "c" ] || [ $EXTENSION = "cpp" ] || [ $EXTENSION = "cc" ]; then
+      case $EXTENSION in
+        "c") COMPILER="gcc" ;;
+        "cpp" | "cc") COMPILER="g++" ;;
+      esac
+      TARGET+=("${FILE##*/}")
+    fi
+  done
 
-    ORIGIN=$(pwd)
-    cd $CONTAINER_PATH
+  ORIGIN=$(pwd)
+  cd $CONTAINER_PATH
 
-    # This is where the magic happens
-    docker run -ti -v $PWD:/test halyard:0.1 bash -c \
-        "cd /test/; $COMPILER -o memtest ${TARGET[*]} && valgrind --leak-check=full ./memtest";
+  # This is where the magic happens
+  docker run -ti -v $PWD:/test halyard:0.1 bash -c \
+    "cd /test/; $COMPILER -o memtest ${TARGET[*]} && valgrind --leak-check=full ./memtest"
 
-    rm memtest
-    cd $ORIGIN
+  rm memtest
+  cd $ORIGIN
 }
 
 peek() {
-    for FILE in $CONTAINER_PATH/* ; do
-        if [ ${FILE##*/} != "Dockerfile" ] ; then
-            echo "${FILE##*/}"
-        fi
-    done
+  for FILE in $CONTAINER_PATH/*; do
+    if [ ${FILE##*/} != "Dockerfile" ]; then
+      echo "${FILE##*/}"
+    fi
+  done
 }
 
 clean() {
-    for FILE in $CONTAINER_PATH/* ; do
-        if [ ${FILE##*/} != "Dockerfile" ] ; then
-            echo "Removing ${FILE##*/}"
-            rm $FILE
-        fi
-    done
+  for FILE in $CONTAINER_PATH/*; do
+    if [ ${FILE##*/} != "Dockerfile" ]; then
+      echo "Removing ${FILE##*/}"
+      rm $FILE
+    fi
+  done
 }
 
-case "$1" in 
-    "load")  load "${@:2}" ;;
-    "run")   run  "${@:2}" ;;
-    "peek")  peek  ;;
-    "clean") clean ;;
+case "$1" in
+  "load") load "${@:2}" ;;
+  "run") run "${@:2}" ;;
+  "peek") peek ;;
+  "clean") clean ;;
 esac


### PR DESCRIPTION
In accordance with the [Google Style Guide](https://google.github.io/styleguide/shell.xml?showone=Indentation#Indentation), I used [shfmt](https://github.com/mvdan/sh) to format indentation.

This gets the code closer to conforming with the style guide. Below is the command and flags I used to get the formatting.

```sh
$ shfmt -i 2 -ci
```
I wanted to do this incrementally. Reading your comment in the README made me think twice about testing. That is, I wanted to test everything (formatting shouldn't break anything). I would run a quick test before/if you merge this.