### PR TITLE
more style compliance, untangled logic

### DIFF
--- a/halyard
+++ b/halyard
@@ -4,17 +4,17 @@
 # https://google.github.io/styleguide/shell.xml
 
 # Probably will change to /usr/local/opt
-HALYARD_PATH="$HOME/halyard"
-CONTAINER_PATH="$HALYARD_PATH/container"
+readonly HALYARD_PATH="$HOME/halyard"
+readonly CONTAINER_PATH="$HALYARD_PATH/container"
 
 copy_files() {
   # Optional flag
-  OPT=$1
-  FILES="${@:2}"
+  local opt=$1
+  local files="${@:2}"
 
-  for FILE in $FILES; do
-    echo "Loading ${FILE##*/}"
-    cp $OPT $FILE $CONTAINER_PATH
+  for file in $files; do
+    echo "Loading ${file##*/}"
+    cp $opt $file $CONTAINER_PATH
   done
 }
 
@@ -22,74 +22,83 @@ load() {
   cat $HALYARD_PATH/images/logo
 
   # Initially we are looking at all args
-  TARGET="$@"
+  local target=("$@")
+  local dir_change
+  local arg
+  local opt
 
   if [ $1 = "-y" ]; then
-    ARG=$2
+    arg=$2
     # If --yes option is provided, target begins at 2nd arg
-    TARGET="${@:2}"
+    unset target[0]
   else
-    ARG=$1
-    OPT=-i
+    arg=$1
+    opt=-i
   fi
 
-  if [ -d $ARG ]; then
+  if [ -d $arg ]; then
     echo "Preparing contents of ${PWD##*/}..."
     # Since provided target is a dir, switch target to its contents
-    TARGET=$ARG/*
+    unset target
+    pushd "$arg" > /dev/null 2>&1
+    target="$(ls .)"
   fi
 
-  copy_files "${OPT}" "${TARGET}"
+  copy_files "${opt}" "${target[@]}"
+  popd > /dev/null 2>&1
 }
 
 run() {
   # Ensure Docker Desktop is up
   open --background -a Docker &&
-    if ! docker system info >/dev/null 2>&1; then
+    if ! docker system info > /dev/null 2>&1; then
       echo "Staring Docker..." &&
-        while ! docker system info >/dev/null 2>&1; do
+        while ! docker system info > /dev/null 2>&1; do
           sleep 1
         done
     fi
 
-  TARGET=() # Container for source files
+  local target=() # Container for source files
+  local extension
+  local compiler
 
-  for FILE in $CONTAINER_PATH/*; do
-    EXTENSION="${FILE##*.}"
+  for file in $CONTAINER_PATH/*; do
+    extension="${file##*.}"
     # Set compiler based on source extension
-    if [ $EXTENSION = "c" ] || [ $EXTENSION = "cpp" ] || [ $EXTENSION = "cc" ]; then
-      case $EXTENSION in
-        "c") COMPILER="gcc" ;;
-        "cpp" | "cc") COMPILER="g++" ;;
+    if [ $extension = "c" ] || [ $extension = "cpp" ] || [ $extension = "cc" ]; then
+      case $extension in
+        "c") compiler="gcc" ;;
+        "cpp" | "cc") compiler="g++" ;;
       esac
-      TARGET+=("${FILE##*/}")
+      target+=("${file##*/}")
     fi
   done
 
-  ORIGIN=$(pwd)
-  cd $CONTAINER_PATH
+  pushd $CONTAINER_PATH > /dev/null 2>&1
 
   # This is where the magic happens
   docker run -ti -v $PWD:/test halyard:0.1 bash -c \
-    "cd /test/; $COMPILER -o memtest ${TARGET[*]} && valgrind --leak-check=full ./memtest"
+    "cd /test/; $compiler -o memcheck ${target[*]} && valgrind --leak-check=full ./memcheck"
 
-  rm memtest
-  cd $ORIGIN
+  rm memcheck
+  popd > /dev/null 2>&1
 }
 
 peek() {
-  for FILE in $CONTAINER_PATH/*; do
-    if [ ${FILE##*/} != "Dockerfile" ]; then
-      echo "${FILE##*/}"
+  local loaded_files=$CONTAINER_PATH/*
+  for file in $loaded_files; do
+    if [ ${file##*/} != "Dockerfile" ]; then
+      echo "${file##*/}"
     fi
   done
 }
 
-clean() {
-  for FILE in $CONTAINER_PATH/*; do
-    if [ ${FILE##*/} != "Dockerfile" ]; then
-      echo "Removing ${FILE##*/}"
-      rm $FILE
+unload() {
+  local loaded_files=$CONTAINER_PATH/*
+  for file in $loaded_files; do
+    if [ ${file##*/} != "Dockerfile" ]; then
+      echo "Unloading ${file##*/}"
+      rm $file
     fi
   done
 }
@@ -98,5 +107,5 @@ case "$1" in
   "load") load "${@:2}" ;;
   "run") run "${@:2}" ;;
   "peek") peek ;;
-  "clean") clean ;;
+  "unload") unload ;;
 esac


### PR DESCRIPTION
Style guide compliance:
- Lowercase variable names
- Local variables scoped
- Constants made `readonly`
- Loop iterators given coherent names

>To locally scope the function variables, I had to do a lot of logic untangling - particularly in `load()`.  It was a grotesque mess of re-defined global variables.  To do so, I became more familiar with bash syntax and conventions, (ex: `pushd` and `popd` instead of several `cd`'s, and `unset`ting array values) and as a result, `load` is far more concise. 

Oh yeah, and `clean` is now `unload`

I have extensively tested these changes with no issues.