### PR TITLE
project restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 
 ## Install
 
-***I dont think this will work until the repo is public***
-
 ```bash
 $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/parkerduckworth/halyard/master/install)"
 ```
+- If you do not have permission to write to /usr/local/, you may need to run with sudo
+- Ensure /usr/local/bin is included in $PATH
 
 ## Usage
 

--- a/bin/halyard
+++ b/bin/halyard
@@ -1,0 +1,1 @@
+../libexec/halyard.sh

--- a/install
+++ b/install
@@ -16,7 +16,7 @@ if ! git clone https://github.com/parkerduckworth/halyard > /dev/null 2>&1; then
     echo "Directory named halyard already exists. You must overwrite to continue"
     read -p "Would you like to overwrite? " input
     if [[ $input = 'y' ]]; then
-        rm -R halyard
+        rm -R ./halyard
         git clone https://github.com/parkerduckworth/halyard
     else 
         echo "Shutting down installation..."
@@ -35,7 +35,7 @@ cp -R "$CLONE_PATH"/libexec/* "$PATH_PREFIX"/libexec
 cp -R "$CLONE_PATH"/images/* "$HALYARD_PATH"/images
 cp "$CLONE_PATH"/container/Dockerfile "$CONTAINER_PATH"
 
-cd .. && rm -R halyard
+cd .. && rm -R ./halyard
 
 docker build -t halyard:0.1 "$CONTAINER_PATH"
 echo "Installed Halyard to $PATH_PREFIX/bin/halyard"

--- a/install
+++ b/install
@@ -2,13 +2,42 @@
 
 origin=$(pwd)
 
-cd $HOME && git clone https://github.com/parkerduckworth/halyard && cd halyard
+readonly PATH_PREFIX="/usr/local"
 
-cp halyard /usr/local/bin && chmod +x /usr/local/bin/halyard
+# Permission denied to write here
+if ! mkdir -p "$PATH_PREFIX"/{bin,libexec}; then
+    exit 1
+fi
 
-# Locks Dockerfile
-chflags uchg container/Dockerfile
+cd $HOME
+mkdir -m 0777 {.halyard,.halyard/container,.halyard/images}
 
-docker build -t halyard:0.1 ./container
+if ! git clone https://github.com/parkerduckworth/halyard > /dev/null 2>&1; then
+    echo "Directory named halyard already exists. You must overwrite to continue"
+    read -p "Would you like to overwrite? " input
+    if [[ $input = 'y' ]]; then
+        rm -R halyard
+        git clone https://github.com/parkerduckworth/halyard
+    else 
+        echo "Shutting down installation..."
+        exit 0
+    fi
+fi
+
+cd ./halyard
+
+readonly CLONE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
+readonly HALYARD_PATH="$HOME/.halyard"
+readonly CONTAINER_PATH="$HALYARD_PATH/container"
+
+cp -R "$CLONE_PATH"/bin/* "$PATH_PREFIX"/bin
+cp -R "$CLONE_PATH"/libexec/* "$PATH_PREFIX"/libexec
+cp -R "$CLONE_PATH"/images/* "$HALYARD_PATH"/images
+cp "$CLONE_PATH"/container/Dockerfile "$CONTAINER_PATH"
+
+cd .. && rm -R halyard
+
+docker build -t halyard:0.1 "$CONTAINER_PATH"
+echo "Installed Halyard to $PATH_PREFIX/bin/halyard"
 
 cd $origin

--- a/libexec/halyard.sh
+++ b/libexec/halyard.sh
@@ -3,8 +3,7 @@
 # Will conform to Google style guide
 # https://google.github.io/styleguide/shell.xml
 
-# Probably will change to /usr/local/opt
-readonly HALYARD_PATH="$HOME/halyard"
+readonly HALYARD_PATH="$HOME/.halyard"
 readonly CONTAINER_PATH="$HALYARD_PATH/container"
 
 copy_files() {
@@ -62,7 +61,7 @@ run() {
   local extension
   local compiler
 
-  for file in $CONTAINER_PATH/*; do
+  for file in "$CONTAINER_PATH"/*; do
     extension="${file##*.}"
     # Set compiler based on source extension
     if [ $extension = "c" ] || [ $extension = "cpp" ] || [ $extension = "cc" ]; then
@@ -85,8 +84,7 @@ run() {
 }
 
 peek() {
-  local loaded_files=$CONTAINER_PATH/*
-  for file in $loaded_files; do
+  for file in "$CONTAINER_PATH"/*; do
     if [ ${file##*/} != "Dockerfile" ]; then
       echo "${file##*/}"
     fi
@@ -94,8 +92,7 @@ peek() {
 }
 
 unload() {
-  local loaded_files=$CONTAINER_PATH/*
-  for file in $loaded_files; do
+  for file in "$CONTAINER_PATH"/*; do
     if [ ${file##*/} != "Dockerfile" ]; then
       echo "Unloading ${file##*/}"
       rm $file


### PR DESCRIPTION
## Changes

* `halyard.sh` placed in `libexec`
   * [rationale](https://www.rubydoc.info/github/Homebrew/brew/Formula:libexec)
   * [rationale](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s07.html)
* `halyard` placed in `bin`
* With this new structure, `install` needed to be re-conceived. With `/usr/local/` as default location:
   * Create `bin` and `libexec` if they do not exist. If this fails,  the installation is immediately terminated. (This results in the user knowing whether or not they need to run `sudo`)
   *  Make the hidden dir `.halyard/` in the user's `$HOME` where the `load`ed files will live
   * Ensure that there is not another dir in `$HOME` with the name `halyard`.  If so, an overwriting prompt will require the user to do to continue the process
   * All required files copied to their designated location on disk

> Note: intallation process is intended to write to disk only what is necessary to run the application.  The cloned repository is removed after the required copies are made. 

There are for sure things that still need to be improved in these changed files and in the installation process, but I think this is a step in the right direction.