### PR TITLE
uninstall added

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,20 @@
 
 
 
-## Install
+## (Un)Installation
 
+### Install
 ```bash
 $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/parkerduckworth/halyard/master/install)"
 ```
-- If you do not have permission to write to /usr/local/, you may need to run with sudo
-- Ensure /usr/local/bin is included in $PATH
+- If you do not have permission to write to `/usr/local/`, you may need to run with `sudo`
+- Ensure /usr/local/bin is included in `$PATH`
+
+### Uninstall
+```bash
+$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/parkerduckworth/halyard/master/uninstall)"
+```
+- Similarly, you may need to run with `sudo`
 
 ## Usage
 

--- a/install
+++ b/install
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 origin=$(pwd)
-
+echo "Installing Halyard"
 readonly PATH_PREFIX="/usr/local"
 
 # Permission denied to write here
@@ -10,11 +10,10 @@ if ! mkdir -p "$PATH_PREFIX"/{bin,libexec}; then
 fi
 
 cd $HOME
-mkdir -m 0777 {.halyard,.halyard/container,.halyard/images}
 
 if ! git clone https://github.com/parkerduckworth/halyard > /dev/null 2>&1; then
     echo "Directory named halyard already exists. You must overwrite to continue"
-    read -p "Would you like to overwrite? " input
+    read -p "Would you like to overwrite? (y/n [n]) " input
     if [[ $input = 'y' ]]; then
         rm -R ./halyard
         git clone https://github.com/parkerduckworth/halyard
@@ -24,20 +23,22 @@ if ! git clone https://github.com/parkerduckworth/halyard > /dev/null 2>&1; then
     fi
 fi
 
+mkdir -m 0777 {.halyard,.halyard/container,.halyard/images}
 cd ./halyard
 
 readonly CLONE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 readonly HALYARD_PATH="$HOME/.halyard"
 readonly CONTAINER_PATH="$HALYARD_PATH/container"
 
-cp -R "$CLONE_PATH"/bin/* "$PATH_PREFIX"/bin
-cp -R "$CLONE_PATH"/libexec/* "$PATH_PREFIX"/libexec
-cp -R "$CLONE_PATH"/images/* "$HALYARD_PATH"/images
+cp -vR "$CLONE_PATH"/bin/* "$PATH_PREFIX"/bin
+cp -vR "$CLONE_PATH"/libexec/* "$PATH_PREFIX"/libexec
+cp -vR "$CLONE_PATH"/images/* "$HALYARD_PATH"/images
 cp "$CLONE_PATH"/container/Dockerfile "$CONTAINER_PATH"
 
 cd .. && rm -R ./halyard
 
+echo "Building Docker image. This can take a couple minutes."
 docker build -t halyard:0.1 "$CONTAINER_PATH"
-echo "Installed Halyard to $PATH_PREFIX/bin/halyard"
+echo "Successfully installed Halyard"
 
 cd $origin

--- a/libexec/halyard.sh
+++ b/libexec/halyard.sh
@@ -76,7 +76,7 @@ run() {
   pushd $CONTAINER_PATH > /dev/null 2>&1
 
   # This is where the magic happens
-  docker run -ti -v $PWD:/test halyard:0.1 bash -c \
+  docker run --rm -ti -v $PWD:/test halyard:0.1 bash -c \
     "cd /test/; $compiler -o memcheck ${target[*]} && valgrind --leak-check=full ./memcheck"
 
   rm memcheck

--- a/uninstall
+++ b/uninstall
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+read -p "Uninstalling Halyard. Proceed? (y/n [n]) " input
+if [[ $input != "y" ]]; then
+    exit 0
+fi
+
+echo "Removing Docker image..."
+docker rmi halyard:0.1 2> /dev/null
+
+readonly PATH_PREFIX="/usr/local"
+readonly HALYARD_PATH="$HOME/.halyard"
+
+echo "Removing related files..."
+rm -vR "$HALYARD_PATH"
+rm -v  "$PATH_PREFIX"/bin/halyard
+rm -v  "$PATH_PREFIX"/libexec/halyard.sh
+
+echo "Successfully uninstalled Halyard"


### PR DESCRIPTION
## Changes

* `uninstall` is run the same way as `install`:
```sh
$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/parkerduckworth/halyard/master/uninstall)"
```

* Also, made a few cosmetic changes to `install` in the process.

* While figuring out how to undo all the Docker stuff done by installing, I found that every time we run halyard, a new container is created, and left 'dangling' lol. You can probably see for yourself by running `docker container ls -a`.  To fix this, I added `--rm` to `docker run` command in `halyard.sh`, which removes the container instance after it exits.  
   * [docker docs](https://docs.docker.com/engine/reference/run/#clean-up---rm)