### PR TITLE
fix display, parse options

### DIFF
--- a/libexec/halyard.sh
+++ b/libexec/halyard.sh
@@ -29,32 +29,36 @@ init() {
   fi
 }
 
-# Container status: [LOADED or UNLOADED]
-#STATUS="UNLOADED"
+# Resolve the absolute path for a file in the current directory
+get_abs_path() {
+  echo "$(cd $(dirname "$1"); pwd -P)/$(basename "$1")"
+}
 
 # Utility function that formats and display contents of
 # an array of collected files (file names).
 display() {
+  local file_array=("$@")
+
   local divider=====================================
   local divider=$divider$divideri$divider$divider
 
   local header="\n%-15s %-25s %12s %10s\n"
   local format=""
+  local width=67
 
-  if [[ "$STATUS" == "LOADED" ]]; then
+  if [[ "$STATUS" = "LOADED" ]]; then
     format="\x1b[22;33m%-15s\x1b[0m %-25s \x1b[33m%12s\x1b[0m %10d\n"
   else
     format="%-15s %-25s \x1b[33m%12s\x1b[0m %10d\n"
   fi
 
   printf "${header}" "STATUS" "FILE_NAME" "FILE_EXTENSION" "FILE_SIZE"
-  width=67
-
   printf "%$width.${width}s\n" "$divider"
+
   for file_name in "${file_array[@]}"; do
-    EXTENSION=$([[ "$file_name" == *.* ]] && echo ".${file_name##*.}" || echo '')
+    EXTENSION=$([[ "$file_name" = *.* ]] && echo ".${file_name##*.}" || echo '')
     FILESIZE=$(stat -f '%z' "${file_name}")
-    printf "$format" "[${STATUS}]" "${file_name}" "${EXTENSION} " "${FILESIZE}"
+    printf "$format" "[${STATUS}]" "${file_name##*/}" "${EXTENSION} " "${FILESIZE}"
   done
   printf "\n"
 }
@@ -62,53 +66,57 @@ display() {
 # Load (via cp) the currenty directory's files into toplevel
 # container.
 load_container() {
-  # Optional flag
-  local opt="$1"
-  local files="${@:2}"
+  local files="$@"
   local file_array=()
 
   for file in $files; do
     if [[ ! -d "${file}" ]]; then
-      cp ${opt} ${file} ${CONTAINER_PATH}
-      file_array+=("${file##*/}")
+      if [[ "${OVERWRITE_PROMPT}" = false ]]; then
+        cp ${file} ${CONTAINER_PATH}
+      else
+        cp -i ${file} ${CONTAINER_PATH}
+      fi
+      file_array+=("${file}")
     fi
   done
 
-  display "${file_array[@]}"
+  # display "${file_array[@]}"
 }
 
 # Loads this current directory's files into toplevel
 # docker container.
 load() {
-  cat "${HALYARD_PATH}"/images/logo
+  local args=("$@")
+  local target=()
 
-  # Initially we are looking at all args
-  local target=("$@")
-  local dir_change
-  local arg
-  local opt
-
-  if [ "$1" = "-y" ]; then
-    arg="$2"
-    # If --yes option is provided, target begins at 2nd arg
-    unset target[0]
-  else
-    arg=$1
-    opt=-i
+  if [[ "${#args}" -eq 0 ]]; then
+    echo "Usage: halyard [-y] load [<dir> | <file> | <file 1> ... <file n>]"
+    exit 1
   fi
 
-  if [ -d $arg ]; then
+  cat "${HALYARD_PATH}/images/logo"
+
+  if [[ -d "${args}" ]]; then
     echo "Preparing contents of ${PWD##*/}..."
-    # Since provided target is a dir, switch target to its contents
-    unset target
-    pushd "$arg" >/dev/null 2>&1
-    target="$(ls .)"
+    # Since provided target is a dir, set target to its contents
+    pushd "${args}" > /dev/null 2>&1
+    
+    for file in "$(pwd)"/*; do
+      target+=("$(get_abs_path ${file})")
+    done
+  else
+    # Otherwise target is all passed args
+    for file in "${args[@]}"; do
+      target+=("$(get_abs_path ${file})")
+    done
   fi
 
   STATUS="LOADED"
   # Copy this directory's files into container.
-  load_container "${opt}" "${target[@]}"
-  popd >/dev/null 2>&1
+  load_container "${target[@]}"
+  popd > /dev/null 2>&1 || true
+
+  display "${target[@]}"
 }
 
 run() {
@@ -173,7 +181,7 @@ peek() {
   # to avoid a call to `display` if the vessel is empty.
   for file in "$CONTAINER_PATH"/*; do
     if [ ${file##*/} != "Dockerfile" ]; then
-      file_array+=("${file##*/}")
+      file_array+=("${file}")
       ((file_count = file_count + 1))
     fi
   done
@@ -202,24 +210,44 @@ unload() {
   # to avoid a call to `display` if the vessel is empty.
   for file in "$CONTAINER_PATH"/*; do
     if [ ${file##*/} != "Dockerfile" ]; then
-      file_array+=("${file##*/}")
+      file_array+=("${file}")
       ((file_count = file_count + 1))
-      rm "$file"
     fi
   done
 
-  # Mark status as unloaded and display the files
-  # we unloaded from the vessel.
-  STATUS="UNLOADED"
-
   # Only `display` from `unload` if the vessel has been unloaded.
-  if [[ "$file_count" -gt 0 ]]; then
-    display "${file_array[@]}"
-  else
+  if [[ "$file_count" -eq 0 ]]; then
     printf "\n${HALYARD_SAYS_NO} \`unload\` called on an empty vessel...\n"
     printf "${HALYARD_SAYS} vessel must be \`load[ed]\` before it can be \`unload[ed]\`...\n\n"
+    exit 1
   fi
+
+  # Mark status as unloaded and display the files
+  # being unloaded from the vessel.
+  STATUS="UNLOADED"
+  display "${file_array[@]}"
+
+  for file in "$CONTAINER_PATH"/*; do
+    if [ ${file##*/} != "Dockerfile" ]; then
+      rm "$file"
+    fi
+  done
 }
+
+# Optional flags
+OVERWRITE_PROMPT=true
+
+main() {
+  set -e
+
+  # Parse optional flags
+  # I expect we will have more than this
+  while [[ "${1:0:1}" = "-" ]]; do
+    case "${1:1:1}" in
+      "y") OVERWRITE_PROMPT=false ;;
+    esac
+    shift
+  done
 
 case "$1" in
   "init") init "${@:1}" ;;
@@ -228,3 +256,6 @@ case "$1" in
   "peek") peek ;;
   "unload") unload ;;
 esac
+}
+
+main "$@"


### PR DESCRIPTION
## Changes

- Display was breaking things, because it was attempting to run `stat` on files using relative paths. To clear this up, a function `get_abs_path()` was added, and is called when files are added to the various command `file_array`s, which get passed on to display. 
- A `main()` function was added that handles, then strips away optional parameters, reflecting the options in global variables.  I think it makes more sense to do it this way, because as more options are added, it will become difficult to pass every possible option to every function that needs its state.
- `unload` had to be rearranged a bit, because it was attempting to remove files, before calling `display`, which resulted in `stat` being run on nonexistent files.  As it stands, `display` loops over the files twice -- once to count and them to `file_array`, and once to remove them, `display`ing in between.  There is likely a better way to do this, but for now, it is robust and it works.  `unload` still checks the `file_count` before sending the array to `display`

#### Minor Changes

- In `display`, `width` was not declared local, and file_array` was used, but never declared
- All `==` equality operators were changed to `=` to be compliant with [POSIX standards](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html)
