### PR TITLE
tests added

### DIFF
--- a/libexec/halyard.sh
+++ b/libexec/halyard.sh
@@ -89,8 +89,8 @@ load() {
   local args=("$@")
   local target=()
 
-  if [[ "${#args}" -eq 0 ]]; then
-    echo "Usage: halyard [-y] load [<dir> | <file> | <file 1> ... <file n>]"
+  if [[ "${#args[@]}" -eq 0 ]]; then
+    echo "usage: halyard [-y] load [<dir> | <file> | <file 1> ... <file n>]"
     exit 1
   fi
 
@@ -99,7 +99,7 @@ load() {
   if [[ -d "${args}" ]]; then
     echo "Preparing contents of ${PWD##*/}..."
     # Since provided target is a dir, set target to its contents
-    pushd "${args}" > /dev/null 2>&1
+    pushd "${args}" >/dev/null 2>&1
     
     for file in "$(pwd)"/*; do
       target+=("$(get_abs_path ${file})")
@@ -239,6 +239,11 @@ OVERWRITE_PROMPT=true
 
 main() {
   set -e
+
+  if [[ "$#" -eq 0 ]]; then
+    echo "usage: halyard [-y] <command> [<args>]"
+    exit 1
+  fi
 
   # Parse optional flags
   # I expect we will have more than this

--- a/test/halyard.bats
+++ b/test/halyard.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "display logo" {
+  run cat "${HALYARD_PATH}"/images/logo
+  [ "$status" -eq 0 ]
+}
+
+@test "load called with directory: no requested overwrite permission" {
+  run halyard -y load testfiles
+  [ "$status" -eq 0 ]
+  rm "${CONTAINER_PATH}"/test.cpp
+  rm "${CONTAINER_PATH}"/test.hpp
+}
+
+@test "load called with directory: requested overwrite permission" {
+  run halyard load testfiles
+  yes | run halyard load testfiles
+  [ "$status" -eq 0 ]
+  rm "${CONTAINER_PATH}"/test.cpp
+  rm "${CONTAINER_PATH}"/test.hpp
+}
+
+@test "load called with single file: no requested overwrite permission" {
+  run halyard -y load testfiles/test.cpp
+  [ "$status" -eq 0 ]
+  rm "${CONTAINER_PATH}"/test.cpp
+}
+
+@test "load called with single file: requested overwrite permission" {
+  run halyard load testfiles/test.cpp
+  yes | run halyard load testfiles/test.cpp
+  [ "$status" -eq 0 ]
+  rm "${CONTAINER_PATH}"/test.cpp
+}
+
+@test "load called with multiple files: no requested overwrite permission" {
+  run halyard -y load testfiles/test.cpp testfiles/test.hpp
+  [ "$status" -eq 0 ]
+  rm "${CONTAINER_PATH}"/test.cpp
+  rm "${CONTAINER_PATH}"/test.hpp
+}
+
+@test "load called with multiple files: requested overwrite permission" {
+  run halyard load testfiles/test.cpp testfiles/test.hpp
+  yes | run halyard load testfiles/test.cpp testfiles/test.hpp
+  [ "$status" -eq 0 ]
+  rm "${CONTAINER_PATH}"/test.cpp
+  rm "${CONTAINER_PATH}"/test.hpp
+}
+
+@test "load called without args: usage displayed and exit status 1" {
+  run halyard load
+  [ "$status" -eq 1 ]
+  [ $(expr "${lines[0]}" : "usage:") -ne 0 ]
+}
+
+@test "halyard executed without args: usage displayed and exit status 1" {
+  run halyard
+  [ "$status" -eq 1 ]
+  [ $(expr "${lines[0]}" : "usage:") -ne 0 ]
+}
+
+

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+
+setup() {
+  export HALYARD_PATH="${HOME}/.halyard"
+  export CONTAINER_PATH="${HALYARD_PATH}/container"
+}
+
+teardown() {
+  rm "${CONTAINER_PATH}/test.cpp" || true
+  rm "${CONTAINER_PATH}/test.hpp" || true
+}

--- a/test/testfiles/test.cpp
+++ b/test/testfiles/test.cpp
@@ -1,0 +1,7 @@
+#include "test.hpp"
+
+int main()
+{
+    Test<int> T;
+    return 0;
+}

--- a/test/testfiles/test.hpp
+++ b/test/testfiles/test.hpp
@@ -1,0 +1,14 @@
+#ifndef TEST_H
+#define TEST_H
+
+template <typename T> 
+class Test {
+public:
+    Test() { data = new T; }
+    ~Test() { delete data; }
+    
+private:
+    T *data;
+};
+
+#endif


### PR DESCRIPTION
## Finally we have automated testing

- How to run:
   - `cd` into `test`
   - `$ bats halyard.bats`

- Used a bit of TDD to better handle some erroneous input, including usage displays
- `test/testfiles` contains some dummy files for testing purposes.  They actually compile though, and may be useful to test Memcheck output parsing or  something down the line
- We need more tests! A lot more. Currently covered:
   - `load()`
   - logo display
   - `halyard` evocation without arguments
-  Looking ahead, we can probably split up testing into related suites as their number increases