### PR TITLE
makefile detection

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -2,4 +2,4 @@ FROM ubuntu:18.04
 
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN apt-get install g++ valgrind -y
+RUN apt-get install build-essential valgrind -y


### PR DESCRIPTION
## Changes

- `container/Dockerfile`:
   - To enable `make`, Ubuntu's [build-essential](https://packages.ubuntu.com/xenial/build-essential) package is fetched rather than just g++. This should give us everything we need to build C/C++  executables

- `libexec/halyard.sh`:
   - In display, we had `EXTENSION=$([[ "$file_name" = *.* ]] && echo ".${file_name##*.}" || echo '')`, truncating everything before the last occurring `.`.  Due to makefile's lack of an extension, and `.halyard`'s file name, makefiles were being displayed as `.halyard/container/makefile`.  I have introduced `local trunc_file_name="${file_name##*/}"`, which truncates the absolute path prior to processing for extensions.  It replaces `"$file_name"` in all succeeding calls.
   - Halyard now supports the copying of full nested directories, by way of adding `-R` to the `load_container()` and `unload()` functions, and altering some of the `[[ ]]` tests to allow for it.
   - The `open --background -a Docker` and `docker run` commands were given their own functions, `docker_start()` and  `docker_run()` respectively.
   - makefiles are tested for in `run()` by running the contents of `container` through grep and setting a bool flag. The outcome of this test is passed to `docker_run()`.