### PR TITLE
updated existing tests, added additional tests

### DIFF
--- a/libexec/halyard.sh
+++ b/libexec/halyard.sh
@@ -74,8 +74,12 @@ load_container() {
   local files="$@"
   local file_array=()
 
-  for file in $files; do
-    rsync -a ${file} ${CONTAINER_PATH}
+  for file in "${files}"; do
+    if [[ ! -f "${file}" ]] || [[ ! -d "${file}" ]]; then
+      printf "\n${HALYARD_SAYS_NO} ${file} does not exist\n\n"
+      exit 1
+    fi
+    rsync -a "${file}" "${CONTAINER_PATH}"
     file_array+=("${file}")
   done
 }
@@ -139,8 +143,6 @@ load() {
     exit 1
   fi
 
-  cat "${HALYARD_PATH}/images/logo"
-
   # Metadata for contained files
   touch "${CONTAINER_PATH}"/.paths
 
@@ -165,8 +167,10 @@ load() {
   load_container "${target[@]}"
   popd >/dev/null 2>&1 || true
 
-  # Everything went well, mark status as loaded.
+  # Everything went well, mark status as loaded
   STATUS="LOADED"
+  
+  cat "${HALYARD_PATH}/images/logo"
   display "${target[@]}"
 }
 

--- a/libexec/halyard.sh
+++ b/libexec/halyard.sh
@@ -71,11 +71,11 @@ display() {
 # Load (via rsync) the currenty directory's files into toplevel
 # container.
 load_container() {
-  local files="$@"
+  local files=("$@")
   local file_array=()
 
-  for file in "${files}"; do
-    if [[ ! -f "${file}" ]] || [[ ! -d "${file}" ]]; then
+  for file in "${files[@]}"; do
+    if [[ ! -f "${file}" ]] && [[ ! -d "${file}" ]]; then
       printf "\n${HALYARD_SAYS_NO} ${file} does not exist\n\n"
       exit 1
     fi
@@ -147,8 +147,8 @@ load() {
   touch "${CONTAINER_PATH}"/.paths
 
   if [[ -d "${args}" ]]; then
-    echo "Preparing contents of ${PWD##*/}..."
     pushd "${args}" >/dev/null 2>&1
+    echo "Preparing contents of ${PWD##*/}..."
     # Since provided target is a dir, set target to its contents
     target_location=("$(pwd)"/*)
   else
@@ -169,7 +169,7 @@ load() {
 
   # Everything went well, mark status as loaded
   STATUS="LOADED"
-  
+
   cat "${HALYARD_PATH}/images/logo"
   display "${target[@]}"
 }

--- a/test/halyard.bats
+++ b/test/halyard.bats
@@ -7,47 +7,77 @@ load test_helper
   [ "$status" -eq 0 ]
 }
 
-@test "load called with directory: no requested overwrite permission" {
-  run halyard -y load testfiles
-  [ "$status" -eq 0 ]
-  rm "${CONTAINER_PATH}"/test.cpp
-  rm "${CONTAINER_PATH}"/test.hpp
+@test "halyard executed without args" {
+  run halyard
+  [ "$status" -eq 1 ]
+  [ $(expr "${lines[0]}" : "usage:") -ne 0 ]
 }
 
-@test "load called with directory: requested overwrite permission" {
+@test "load called with directory" {
   run halyard load testfiles
-  yes | run halyard load testfiles
   [ "$status" -eq 0 ]
+  [ -f "${CONTAINER_PATH}"/test.cpp ]
+  [ -f "${CONTAINER_PATH}"/test.hpp ]
+  [ -f "${CONTAINER_PATH}"/.paths ]
   rm "${CONTAINER_PATH}"/test.cpp
   rm "${CONTAINER_PATH}"/test.hpp
+  rm "${CONTAINER_PATH}"/.paths
 }
 
-@test "load called with single file: no requested overwrite permission" {
-  run halyard -y load testfiles/test.cpp
-  [ "$status" -eq 0 ]
-  rm "${CONTAINER_PATH}"/test.cpp
-}
-
-@test "load called with single file: requested overwrite permission" {
+@test "load called with single file" {
   run halyard load testfiles/test.cpp
-  yes | run halyard load testfiles/test.cpp
   [ "$status" -eq 0 ]
+  [ -f "${CONTAINER_PATH}"/test.cpp ]
+  [ -f "${CONTAINER_PATH}"/.paths ]
   rm "${CONTAINER_PATH}"/test.cpp
+  rm "${CONTAINER_PATH}"/.paths
 }
 
-@test "load called with multiple files: no requested overwrite permission" {
-  run halyard -y load testfiles/test.cpp testfiles/test.hpp
-  [ "$status" -eq 0 ]
-  rm "${CONTAINER_PATH}"/test.cpp
-  rm "${CONTAINER_PATH}"/test.hpp
-}
-
-@test "load called with multiple files: requested overwrite permission" {
+@test "load called with multiple files" {
   run halyard load testfiles/test.cpp testfiles/test.hpp
-  yes | run halyard load testfiles/test.cpp testfiles/test.hpp
+  [ "$status" -eq 0 ]
+  [ -f "${CONTAINER_PATH}"/test.cpp ]
+  [ -f "${CONTAINER_PATH}"/test.hpp ]
+  [ -f "${CONTAINER_PATH}"/.paths ]
+  rm "${CONTAINER_PATH}"/test.cpp
+  rm "${CONTAINER_PATH}"/test.hpp
+  rm "${CONTAINER_PATH}"/.paths
+}
+
+@test "peek called on loaded container" {
+  run halyard load testfiles
+  run halyard peek
   [ "$status" -eq 0 ]
   rm "${CONTAINER_PATH}"/test.cpp
   rm "${CONTAINER_PATH}"/test.hpp
+  rm "${CONTAINER_PATH}"/.paths
+}
+
+@test "unload called on loaded container" {
+  run halyard load testfiles
+  run halyard unload
+  [ ! -f "${CONTAINER_PATH}"/test.cpp ]
+  [ ! -f "${CONTAINER_PATH}"/test.hpp ]
+  [ ! -f "${CONTAINER_PATH}"/.paths ]
+  [ "$status" -eq 0 ]
+}
+
+@test "reload called on loaded container" {
+  run halyard load testfiles
+  run halyard reload
+  [ "$status" -eq 0 ]
+  rm "${CONTAINER_PATH}"/test.cpp
+  rm "${CONTAINER_PATH}"/test.hpp
+  rm "${CONTAINER_PATH}"/.paths
+}
+
+@test "run called on loaded container" {
+  run halyard load testfiles
+  run halyard run
+  [ "$status" -eq 0 ]
+  rm "${CONTAINER_PATH}"/test.cpp
+  rm "${CONTAINER_PATH}"/test.hpp
+  rm "${CONTAINER_PATH}"/.paths
 }
 
 @test "load called without args: usage displayed and exit status 1" {
@@ -56,10 +86,22 @@ load test_helper
   [ $(expr "${lines[0]}" : "usage:") -ne 0 ]
 }
 
-@test "halyard executed without args: usage displayed and exit status 1" {
-  run halyard
+@test "peek called on empty container: exit status 1" {
+  run halyard peek
   [ "$status" -eq 1 ]
-  [ $(expr "${lines[0]}" : "usage:") -ne 0 ]
 }
 
+@test "unload called on empty container: exit status 1" {
+  run halyard unload
+  [ "$status" -eq 1 ]
+}
 
+@test "reload called on empty container: exit status 1" {
+  run halyard reload
+  [ "$status" -eq 1 ]
+}
+
+@test "run called on empty container: exit status 1" {
+  run halyard run
+  [ "$status" -eq 1 ]
+}

--- a/test/halyard.bats
+++ b/test/halyard.bats
@@ -26,9 +26,6 @@ load test_helper
   [ -f "${CONTAINER_PATH}"/test.cpp ]
   [ -f "${CONTAINER_PATH}"/test.hpp ]
   [ -f "${CONTAINER_PATH}"/.paths ]
-  rm "${CONTAINER_PATH}"/test.cpp
-  rm "${CONTAINER_PATH}"/test.hpp
-  rm "${CONTAINER_PATH}"/.paths
 }
 
 @test "load called with single file" {
@@ -36,8 +33,6 @@ load test_helper
   [ "$status" -eq 0 ]
   [ -f "${CONTAINER_PATH}"/test.cpp ]
   [ -f "${CONTAINER_PATH}"/.paths ]
-  rm "${CONTAINER_PATH}"/test.cpp
-  rm "${CONTAINER_PATH}"/.paths
 }
 
 @test "load called with multiple files" {
@@ -46,18 +41,12 @@ load test_helper
   [ -f "${CONTAINER_PATH}"/test.cpp ]
   [ -f "${CONTAINER_PATH}"/test.hpp ]
   [ -f "${CONTAINER_PATH}"/.paths ]
-  rm "${CONTAINER_PATH}"/test.cpp
-  rm "${CONTAINER_PATH}"/test.hpp
-  rm "${CONTAINER_PATH}"/.paths
 }
 
 @test "peek called on loaded container" {
   run halyard load testfiles
   run halyard peek
   [ "$status" -eq 0 ]
-  rm "${CONTAINER_PATH}"/test.cpp
-  rm "${CONTAINER_PATH}"/test.hpp
-  rm "${CONTAINER_PATH}"/.paths
 }
 
 @test "unload called on loaded container" {
@@ -73,18 +62,12 @@ load test_helper
   run halyard load testfiles
   run halyard reload
   [ "$status" -eq 0 ]
-  rm "${CONTAINER_PATH}"/test.cpp
-  rm "${CONTAINER_PATH}"/test.hpp
-  rm "${CONTAINER_PATH}"/.paths
 }
 
 @test "run called on loaded container" {
   run halyard load testfiles
   run halyard run
   [ "$status" -eq 0 ]
-  rm "${CONTAINER_PATH}"/test.cpp
-  rm "${CONTAINER_PATH}"/test.hpp
-  rm "${CONTAINER_PATH}"/.paths
 }
 
 @test "load called without args: usage displayed and exit status 1" {

--- a/test/halyard.bats
+++ b/test/halyard.bats
@@ -13,6 +13,13 @@ load test_helper
   [ $(expr "${lines[0]}" : "usage:") -ne 0 ]
 }
 
+@test "init creates \`yard\` directory" {
+  run halyard init
+  [ "$status" -eq 0 ]
+  [ -d "yard" ]
+  rm -R "yard"
+}
+
 @test "load called with directory" {
   run halyard load testfiles
   [ "$status" -eq 0 ]

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -6,6 +6,7 @@ setup() {
 }
 
 teardown() {
-  rm "${CONTAINER_PATH}/test.cpp" || true
-  rm "${CONTAINER_PATH}/test.hpp" || true
+  rm -f "${CONTAINER_PATH}"/test.cpp
+  rm -f "${CONTAINER_PATH}"/test.hpp
+  rm -f "${CONTAINER_PATH}"/.paths
 }


### PR DESCRIPTION
## Changes

- `cp -R` changed to `rsync -a` to isolate errors, because as per `man cp`, "In -R mode, cp will continue copying even if errors are detected."

- Some TDD revealed more uncaught errors in `halyard.sh`, which are fixed here 

- `/test/` update to reflect the removal of the `-y` option

- Additional tests added to increase coverage